### PR TITLE
Fix syntax for ynh_script_progression command

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,7 @@ chown -R $app:www-data "$install_dir"
 #=================================================
 # SETUP FAIL2BAN
 #=================================================
-ynh_script_progression --message="Configuring Fail2Ban..."
+ynh_script_progression "Configuring Fail2Ban..."
 
 # Create a dedicated Fail2Ban config
 ynh_config_add_fail2ban --logpath="/var/log/nginx/$domain-access.log"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ chown -R $app:www-data "$install_dir"
 #=================================================
 # SETUP FAIL2BAN
 #=================================================
-ynh_script_progression --message="Configuring Fail2Ban..."
+ynh_script_progression "Configuring Fail2Ban..."
 
 # Create a dedicated Fail2Ban config
 ynh_config_add_fail2ban --logpath="/var/log/nginx/$domain-access.log"


### PR DESCRIPTION
## Problem

- When upgrading, it displays `--message="Configuring Fail2Ban..."` instead of `Configuring Fail2Ban`:

```
root@instance-20251122-1221:/root# yunohost app upgrade glpi --url https://github.com/eduardomozart/glpi_ynh/tree/patch-6
Info: Now upgrading glpi…
Info: Creating a safety backup prior to the upgrade
Info: Collecting files to be backed up for glpi…
Info: Declaring files to be backed up...
Info: Backing up the MySQL database...
Info: Backup script completed for glpi. (YunoHost will then actually copy those files to the archive).
Info: Creating a backup archive from the collected files…
Info: The archive will contain about 409MB of data.
Success! Backup created: glpi-pre-upgrade2
Info: Backup glpi-pre-upgrade1 was deleted because it is replaced by a newer backup glpi-pre-upgrade2
Info: Updating sources...
Info: Updating system_user...
Info: Updating install_dir...
Info: Updating permissions...
Info: Updating apt...
Info: Updating database...
Info: [+++.................] > Upgrading source files...
Info: [###+++..............] > Updating the database...
Info: [######++++..........] > --message=Configuring Fail2Ban...
Info: The service fail2ban has correctly executed the action reload-or-restart.
Info: [##########+++.......] > Upgrading system configurations related to glpi...
Info: [#############+++....] > Setting up time zones...
Info: [####################] > Upgrade of glpi completed
```

## Solution

- *And how do you fix that problem*

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
