### PR TITLE
Add php8.3-bcmath dependency to `testing` branch

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -73,6 +73,7 @@ ram.runtime = "50M"
         "php8.3-xmlrpc",
         "php8.3-bz2",
         "php8.3-zip",
+        "php8.3-bcmath",
     ]
 
     [resources.database]


### PR DESCRIPTION
## Problem

`php8.3-bcmath` is present on `master` but not on the `testing` branch.

## Solution

Add `php8.3-bcmath` extension to `manifest.toml`.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
